### PR TITLE
Fix large logotype alignment in header

### DIFF
--- a/app/assets/sass/_header.scss
+++ b/app/assets/sass/_header.scss
@@ -20,15 +20,10 @@
   }
 
   // Height of crown is 30px.
-  // Accept slightly larger icons with a height of 35px
+  // Visually adjust placement to accept larger icons with a height of 35px
   .app-header__logotype--large {
-    // Visually adjust placement
-    margin: -3px 0 -8px;
-
-    .govuk-header__link--homepage:not(:focus):hover & {
-      // Prevent underline interfering with larger logo, whose height means
-      // it falls below the baseline
-      background-color: govuk-colour("black");
-    }
+    margin-bottom: -10px;
+    position: relative;
+    top: -3px;
   }
 }


### PR DESCRIPTION
Matches the equivalent fix in the GOV.UK Eleventy Plugin (https://github.com/x-govuk/govuk-eleventy-plugin/pull/159)