### PR TITLE
Add DfE to ESFA services

### DIFF
--- a/app/services/apprenticeship-levy.json
+++ b/app/services/apprenticeship-levy.json
@@ -6,7 +6,10 @@
   ],
   "description": "This service is for organisations that want to take on apprentices. Use this service to set up and manage apprenticeship training and pay for apprenticeship training.",
   "theme": "Education, training and skills",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "phase": "beta",
   "start-page": "https://www.gov.uk/sign-in-apprenticeship-service-account",
   "liveservice": "https://accounts.manage-apprenticeships.service.gov.uk/service",

--- a/app/services/find-a-learning-aim.json
+++ b/app/services/find-a-learning-aim.json
@@ -1,7 +1,10 @@
 {
   "name": "Find a learning aim",
   "description": "Find the latest information on available Qualifications, Standards, Apprenticeships, T Levels and Units.",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "theme": "Education, training and skills",
   "phase": "live",
   "liveservice": "https://submit-learner-data.service.gov.uk/find-a-learning-aim/",

--- a/app/services/find-apprenticeship.json
+++ b/app/services/find-apprenticeship.json
@@ -2,7 +2,10 @@
   "name": "Find an apprenticeship",
   "description": "Search the find an apprenticeship service for apprenticeships in England.",
   "theme": "Education, training and skills",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "phase": "live",
   "start-page": "https://www.gov.uk/apply-apprenticeship",
   "liveservice": "https://www.findapprenticeship.service.gov.uk/apprenticeshipsearch",

--- a/app/services/find-endpoint-assessment-organisation-apprentice.json
+++ b/app/services/find-endpoint-assessment-organisation-apprentice.json
@@ -4,7 +4,10 @@
     "Find an assessor for your apprentice"
   ],
   "description": "Find an organisation to assess your apprentice at the end of their apprenticeship. This is known as an ‘end-point assessment’.",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "theme": "Education, training and skills",
   "phase": "beta",
   "liveservice": "https://find-epao.apprenticeships.education.gov.uk/courses",

--- a/app/services/find-traineeship.json
+++ b/app/services/find-traineeship.json
@@ -1,7 +1,10 @@
 {
   "name": "Find a traineeship",
   "description": "A traineeship is a course with work experience that gets you ready for work or an apprenticeship. It can last from 6 weeks up to 1 year, though most traineeships last for less than 6 months.",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "theme": "Working, jobs and pensions",
   "phase": "live",
   "liveservice": "https://www.findapprenticeship.service.gov.uk/traineeshipsearch",

--- a/app/services/get-help-with-esfa-services.json
+++ b/app/services/get-help-with-esfa-services.json
@@ -1,7 +1,10 @@
 {
   "name": "Get help with Education and Skills Funding Agency services",
   "description": "Self-service support options for education providers hosted by the ESFA.",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "theme": "Education, training and skills",
   "phase": "beta",
   "liveservice": "https://esfahelp.education.gov.uk/"

--- a/app/services/nationalcareers.json
+++ b/app/services/nationalcareers.json
@@ -1,7 +1,10 @@
 {
   "name": "National Careers Service",
   "description": "Information, advice and guidance to help you make decisions on learning, training and work.",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "theme": "Education, training and skills",
   "phase": "beta",
   "liveservice": "https://nationalcareers.service.gov.uk",

--- a/app/services/recruit-an-apprentice.json
+++ b/app/services/recruit-an-apprentice.json
@@ -7,7 +7,10 @@
   ],
   "description": "This service is for registered training providers (including large employers with direct grant funding) to post vacancies and manage applications for apprenticeships and traineeships.",
   "theme": "Education, training and skills",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "phase": "unknown",
   "start-page": [
     "https://www.gov.uk/recruit-apprentice",

--- a/app/services/register-apprenticeship-training-providers.json
+++ b/app/services/register-apprenticeship-training-providers.json
@@ -5,7 +5,10 @@
   ],
   "description": "The Register of Apprenticeship Training Providers (RoATP) is a list of organisations that are eligible to receive government funding to train apprentices.",
   "theme": "Education, training and skills",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "phase": "beta",
   "start-page": "https://www.gov.uk/guidance/register-of-apprenticeship-training-providers",
   "liveservice": "https://download.apprenticeships.education.gov.uk"

--- a/app/services/submit-learner-data.json
+++ b/app/services/submit-learner-data.json
@@ -6,7 +6,10 @@
     "Data collection"
   ],
   "description": "Use this service to validate and submit Individualised learner records, Earnings adjustment statements, ESF supplementary data, Funding Claims and FE staff and vacancy data",
-  "organisation": "Education and Skills Funding Agency",
+  "organisation": [
+    "Education and Skills Funding Agency",
+    "Department for Education"
+  ],
   "theme": "Education, training and skills",
   "phase": "live",
   "liveservice": "https://submit-learner-data.service.gov.uk",


### PR DESCRIPTION
ESFA is an agency sponsored by DfE, so it makes sense to also list all these services under DfE.