### PR TITLE
Update Sass settings

### DIFF
--- a/app/assets/sass/_logo.scss
+++ b/app/assets/sass/_logo.scss
@@ -1,3 +1,0 @@
-.app-header__logo {
-  width: auto
-}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -11,7 +11,6 @@ $govuk-link-visited-colour: #333366;
 @import "count";
 @import "header";
 @import "list";
-@import "logo";
 @import "screenshot";
 @import "tag";
 @import "timeline";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,6 +1,3 @@
-$govuk-new-link-styles: true;
-
-// Override the default GOV.UK Frontend font stack
 $govuk-font-family: system-ui, sans-serif;
 $govuk-brand-colour: #28a;
 $govuk-link-colour: #006688;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -15,8 +15,3 @@ $govuk-link-visited-colour: #333366;
 @import "screenshot";
 @import "tag";
 @import "timeline";
-
-// We don't change the global width container width so that examples are the current width.
-.app-width-container {
-  @include govuk-width-container(1100px);
-}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -3,6 +3,9 @@ $govuk-new-link-styles: true;
 // Override the default GOV.UK Frontend font stack
 $govuk-font-family: system-ui, sans-serif;
 $govuk-brand-colour: #28a;
+$govuk-link-colour: #006688;
+$govuk-link-hover-colour: #004466;
+$govuk-link-visited-colour: #333366;
 
 @import "govuk-frontend/dist/govuk/all";
 


### PR DESCRIPTION
- Use new X-GOVUK link state colours
- Remove deprecated `$govuk-new-link-styles` setting (deprecated in GOV.UK Frontend v5.0)
- Remove unused `.app-width-container` rule (pretty sure this was copied over from the stylesheet for GOV.UK Components)
- Remove `_logo.scss` as it contains a duplicate `.app-header__logo` rule