### PR TITLE
Add app.json for Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "GOV.UK Services List",
+  "description": "A community-maintained list of digital services from the UK government",
+  "website": "https://govuk-digital-services.herokuapp.com",
+  "repository": "https://github.com/x-govuk/govuk-services-list",
+  "stack": "heroku-24"
+}


### PR DESCRIPTION
This adds documentation to control the deploy of the app on Heroku.

Mainly useful for specifying the "stack".

See https://devcenter.heroku.com/articles/app-json-schema