### PR TITLE
Update theme for Contracts Finder

### DIFF
--- a/app/services/contracts-finder.json
+++ b/app/services/contracts-finder.json
@@ -1,10 +1,9 @@
 {
   "name": "Contracts Finder",
   "description": "Contracts Finder lets you search for information about contracts worth over £12,000 (including VAT) with the government and its agencies.",
-  "theme": "Government Internal",
+  "theme": "Business and self-employed",
   "organisation": "Crown Commercial Service",
   "phase": "Beta",
-  "facing": "internal",
   "liveservice": "https://www.contractsfinder.service.gov.uk",
   "start-page": "https://www.gov.uk/contracts-finder"
 }


### PR DESCRIPTION
Contracts Finder is an external-facing service that allows suppliers to find contract opportunities to bid for, as well as providing public transparency for awarded contracts. It is similar to Find a Tender, which is already categorised as "Business and self-employed".