### PR TITLE
Add 'By phase' tab

### DIFF
--- a/app/views/includes/_header.html
+++ b/app/views/includes/_header.html
@@ -25,7 +25,13 @@
     href: "/organisation",
     text: "By organisation",
     active: section == "organisation"
-  }, {
+  },
+  {
+    href: "/phase",
+    text: "By phase",
+    active: section == "phase"
+  },
+  {
     href: "/contribute",
     text: "Contribute",
     active: section == "contribute"

--- a/app/views/phase.html
+++ b/app/views/phase.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% set section = "phase" %}
+
+{% block pageTitle %}Government digital services{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">By phase</h1>
+
+      {% for phase in phases | reverse %}
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2" id="{{ phase.name | slugify }}">{{ phase.name }}</h2>
+
+        <ul class="govuk-list app-list--services">
+          {%- for project in (projects | sort(attribute="name")) -%}
+            {% if project.phase == phase.name %}
+              <li>
+                <a class="govuk-link" href="/projects/{{project.slug }}">{{ project.name }}</a>
+                {% if project.tags %}
+                  {% for tag in project.tags %}
+                    {% if tag != "Original 25 exemplars" %}
+                      {{ govukTag({text: tag, classes: "govuk-tag--blue app-tag--small"}) }}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      {% endfor %}
+    </div>
+  </div>
+
+{% endblock %}

--- a/start.js
+++ b/start.js
@@ -11,8 +11,13 @@ function slugify(str) {
 
 app.locals.phases = [
   {
-    name: "unknown",
+    name: "Unknown",
     class: "",
+    projects_count: 0
+  },
+  {
+    name: "Retired",
+    class: "grey",
     projects_count: 0
   },
   {
@@ -28,11 +33,6 @@ app.locals.phases = [
   {
     name: "Live",
     class: "green",
-    projects_count: 0
-  },
-  {
-    name: "Retired",
-    class: "grey",
     projects_count: 0
   }
 ]
@@ -252,6 +252,10 @@ app.get('/topic', function(req, res) {
 
 app.get('/organisation', function(req, res) {
     res.render('organisations.html')
+});
+
+app.get('/phase', function(req, res) {
+  res.render('phase.html')
 });
 
 app.get('/top-75', function(req, res) {


### PR DESCRIPTION
This PR adds the 'By phase' tab, letting users browse projects by their phase (addressing https://github.com/x-govuk/govuk-services-list/issues/630)

![image](https://github.com/user-attachments/assets/092afd69-b836-443c-8982-8115ffc1ae73)