### PR TITLE
Update screenshots list

### DIFF
--- a/app/views/domains.njk
+++ b/app/views/domains.njk
@@ -1,7 +1,23 @@
 {% extends "layout.njk" %}
 
-{% set serviceGovUkRegexp = r/service\.gov\.uk/ %}
+{% set govukServiceRegexp = r/service\.gov\.uk/ %}
 {% set title = "Domains" %}
+
+{% macro _serviceDomain(domain) %}
+<li>
+{%- if domain.services | length == 1 -%}
+  {% set service = domain.services | first %}
+  <a class="govuk-link govuk-!-font-weight-bold" href="/service/{{ service.slug }}">{{ domain.name }}</a>
+{%- else %}
+  <b>{{ domain.name }}</b> — {{ domain.services | length }} services
+  <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16 govuk-!-padding-left-5 govuk-!-margin-bottom-4">
+  {%- for service in domain.services -%}
+    <li><a class="govuk-link" href="/service/{{ service.slug }}">{{ service.name }}</a></li>
+  {%- endfor %}
+  </ul>
+{%- endif %}
+</li>
+{% endmacro %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
@@ -10,21 +26,7 @@
 
   <ol class="govuk-list govuk-list--spaced">
   {%- for domain in domains -%}
-    {%- if serviceGovUkRegexp.test(domain.name) -%}
-    <li>
-    {%- if domain.services | length == 1 -%}
-      {% set service = domain.services | first %}
-      <a class="govuk-link govuk-!-font-weight-bold" href="/service/{{ service.slug }}">{{ domain.name }}</a>
-    {%- else %}
-      <b>{{ domain.name }}</b> - {{ domain.services | length }} services
-      <ul class="govuk-list govuk-list--spaced govuk-!-font-size-16 govuk-!-padding-left-5 govuk-!-margin-bottom-4">
-      {%- for service in domain.services -%}
-        <li><a class="govuk-link" href="/service/{{ service.slug }}">{{ service.name }}</a></li>
-      {%- endfor %}
-      </ul>
-    {%- endif %}
-    </li>
-    {%- endif %}
+    {{ _serviceDomain(domain) if govukServiceRegexp.test(domain.name) }}
   {%- endfor %}
   </ol>
 
@@ -32,14 +34,7 @@
 
   <ol class="govuk-list govuk-list--spaced">
   {%- for domain in domains -%}
-    {% if not serviceGovUkRegexp.test(domain.name) %}
-    <li>
-    {%- if domain.services | length == 1 -%}
-      {%- set service = domain.services | first %}
-      <a class="govuk-link govuk-!-font-weight-bold" href="/service/{{ service.slug }}">{{ domain.name }}</a>
-    {%- endif %}
-    </li>
-    {%- endif %}
+    {{ _serviceDomain(domain) if not govukServiceRegexp.test(domain.name) }}
   {%- endfor %}
   </ol>
 {% endblock %}

--- a/app/views/domains.njk
+++ b/app/views/domains.njk
@@ -1,11 +1,10 @@
 {% extends "layout.njk" %}
 
+{% set serviceGovUkRegexp = r/service\.gov\.uk/ %}
 {% set title = "Domains" %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
-
-  {% set serviceGovUkRegexp = r/service\.gov\.uk/ %}
 
   <h2 class="govuk-heading-l">*.service.gov.uk</h2>
 

--- a/app/views/screenshots.njk
+++ b/app/views/screenshots.njk
@@ -1,19 +1,32 @@
 {% extends "layout.njk" %}
 
+{% set serviceGovUkRegexp = r/service\.gov\.uk/ %}
 {% set title = "Screenshots" %}
+
+{% macro _serviceScreenshot(service) %}
+<div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-4">
+  <a class="app-screenshot" href="/service/{{ service.slug }}">
+    <img src="/images/service-screenshots/{{ service.slug }}.png" alt="{{ service.name }}">
+  </a>
+</div>
+{% endmacro %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
 
+  <h2 class="govuk-heading-l">*.service.gov.uk</h2>
+
   <div class="govuk-grid-row">
   {%- for service in services | sort(attribute="name") -%}
-  {%- if service.screenshot -%}
-    <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-4">
-      <a class="app-screenshot" href="/service/{{ service.slug }}">
-        <img src="/images/service-screenshots/{{ service.slug }}.png" alt="{{ service.name }}">
-      </a>
-    </div>
-  {%- endif %}
+    {{ _serviceScreenshot(service) if service.screenshot and serviceGovUkRegexp.test(service.domain) }}
+  {%- endfor %}
+  </div>
+
+  <h2 class="govuk-heading-l">Non service.gov.uk domains</h2>
+
+  <div class="govuk-grid-row">
+  {%- for service in services | sort(attribute="name") -%}
+    {{ _serviceScreenshot(service) if service.screenshot and not serviceGovUkRegexp.test(service.domain) }}
   {%- endfor %}
   </div>
 {% endblock %}

--- a/app/views/screenshots.njk
+++ b/app/views/screenshots.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 
-{% set serviceGovUkRegexp = r/service\.gov\.uk/ %}
+{% set govukServiceRegexp = r/service\.gov\.uk/ %}
 {% set title = "Screenshots" %}
 
 {% macro _serviceScreenshot(service) %}
@@ -18,7 +18,7 @@
 
   <div class="govuk-grid-row">
   {%- for service in services | sort(attribute="name") -%}
-    {{ _serviceScreenshot(service) if service.screenshot and serviceGovUkRegexp.test(service.domain) }}
+    {{ _serviceScreenshot(service) if service.screenshot and govukServiceRegexp.test(service.domain) }}
   {%- endfor %}
   </div>
 
@@ -26,7 +26,7 @@
 
   <div class="govuk-grid-row">
   {%- for service in services | sort(attribute="name") -%}
-    {{ _serviceScreenshot(service) if service.screenshot and not serviceGovUkRegexp.test(service.domain) }}
+    {{ _serviceScreenshot(service) if service.screenshot and not govukServiceRegexp.test(service.domain) }}
   {%- endfor %}
   </div>
 {% endblock %}

--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -81,6 +81,14 @@ export const serviceController = (services) => {
   };
 };
 
+export const screenshotController = (services) => {
+  return (request, response, next) => {
+    services = services.filter((service) => service.phase !== "Retired");
+
+    return response.render("screenshots.njk", { services });
+  };
+};
+
 export const viewController = (request, response, next) => {
   const view = request.params.view || "index";
 

--- a/lib/data.js
+++ b/lib/data.js
@@ -50,7 +50,7 @@ export const getServices = async () => {
 
     if (service.liveService) {
       const { hostname } = new URL(service.liveService);
-      service.domain = hostname.replace(/www\./, "");
+      service.domain = hostname.replace(/^www\.(?!gov\.uk(?:\/|$))/, "");
     }
 
     const verb = service.name.split(" ")[0].toLowerCase();
@@ -130,7 +130,6 @@ export const getDomains = (services) => {
   const servicesGroupedByDomain = Object.groupBy(
     services
       .filter((service) => service.domain)
-      .filter((service) => service.domain !== "gov.uk")
       .filter((service) => service.phase !== "Retired"),
     (service) => service.domain,
   );

--- a/start.js
+++ b/start.js
@@ -11,6 +11,7 @@ import {
   markdownController,
   organisationController,
   projectController,
+  screenshotController,
   serviceController,
   viewController,
 } from "./lib/controllers.js";
@@ -49,6 +50,7 @@ const contributingFile = path.join(import.meta.dirname, "CONTRIBUTING.md");
 
 app.get("/organisation{/:slug}", organisationController(organisations));
 app.get("/projects{/:slug}", projectController);
+app.get("/screenshots", screenshotController(services));
 app.get("/service{/:slug}", serviceController(services));
 app.get("/data.json", (request, response) => response.json({ services }));
 app.get("/contribute", markdownController(contributingFile, "Contributing"));


### PR DESCRIPTION
- Don’t show retired services
- Group screenshots by those on `*.service.gov.uk` domain (should use GOV.UK brand) and those on other domains (may use GOV.UK brand)

Also…

- Include `www.gov.uk` in list of domains 