### PR TITLE
Update Government Security website name

### DIFF
--- a/data/services/security.json
+++ b/data/services/security.json
@@ -1,5 +1,5 @@
 {
-  "name": "GOV.UK UK Government Security",
+  "name": "Government Security",
   "description": "This website is where people across the UK government can find security-related strategies, standards, and guidance, along with the organisations involved in the security profession.",
   "theme": "Government Internal",
   "organisation": "Government Digital Service",


### PR DESCRIPTION
This doesn't seem to be GOV.UK branded any more.